### PR TITLE
feat: add liquid glass scan button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import CameraFeed from './components/CameraFeed';
 import DetectionOverlay from './components/DetectionOverlay';
 import MoodCard from './components/MoodCard';
+import ScanButton from './components/ScanButton';
 
 const App: React.FC = () => {
   return (
     <main className="relative w-full h-dvh overflow-hidden select-none touch-none">
       <CameraFeed />
       <DetectionOverlay />
+      <ScanButton />
       <MoodCard />
     </main>
   );

--- a/frontend/src/components/ScanButton.tsx
+++ b/frontend/src/components/ScanButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import clsx from 'clsx';
+import LiquidGlass from './LiquidGlass';
+
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string;
+}
+
+const ScanButton: React.FC<Props> = ({ className, children, ...rest }) => {
+  return (
+    <button
+      {...rest}
+      className={clsx(
+        'absolute inset-x-0 bottom-8 flex justify-center pointer-events-auto',
+        className
+      )}
+    >
+      <LiquidGlass
+        className={
+          'w-24 h-24 rounded-full flex items-center justify-center ' +
+          'ring-1 ring-white/20 shadow-2xl backdrop-blur-[24px] backdrop-saturate-[180%] ' +
+          'transition-transform duration-300 ease-out active:scale-95'
+        }
+      >
+        {children ?? (
+          <span className="text-xl font-semibold text-white">Scan</span>
+        )}
+      </LiquidGlass>
+    </button>
+  );
+};
+
+export default ScanButton;


### PR DESCRIPTION
## Summary
- add polished ScanButton with LiquidGlass styling
- integrate glassy scan trigger into main app UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d79992108325909d9779d3257b3e