### PR TITLE
feat: add face detection and mood analysis

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tensorflow-models/coco-ssd": "^2.2.2",
+    "@tensorflow/tfjs": "^4.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,90 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import CameraFeed from './components/CameraFeed';
-import DetectionOverlay from './components/DetectionOverlay';
+import DetectionOverlay, { Detection } from './components/DetectionOverlay';
 import MoodCard from './components/MoodCard';
 import ScanButton from './components/ScanButton';
 
+interface MoodState {
+  emoji: string;
+  label: string;
+  confidence: number;
+}
+
+const moodEmojis: Record<string, string> = {
+  happy: '😊',
+  relaxed: '😌',
+  anxious: '😟',
+  fearful: '😨',
+  angry: '😡',
+  confused: '😕',
+};
+
 const App: React.FC = () => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [detection, setDetection] = useState<Detection | null>(null);
+  const [mood, setMood] = useState<MoodState | null>(null);
+
+  const handleScan = async () => {
+    if (!videoRef.current || !detection) return;
+    const [x, y, w, h] = detection.bbox;
+
+    let faceX = x, faceY = y, faceW = w, faceH = h;
+    if (detection.class === 'person') {
+      faceW = w * 0.7;
+      faceH = h * 0.4;
+      faceX = x + (w - faceW) / 2;
+      faceY = y + h * 0.1;
+    } else {
+      faceW = w * 0.6;
+      faceH = h * 0.5;
+      faceX = x + (w - faceW) / 2;
+      faceY = y + h * 0.15;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = faceW;
+    canvas.height = faceH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(
+      videoRef.current,
+      faceX,
+      faceY,
+      faceW,
+      faceH,
+      0,
+      0,
+      faceW,
+      faceH
+    );
+
+    const imageData = canvas.toDataURL('image/jpeg', 0.8);
+
+    try {
+      const res = await fetch('/api/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imageData }),
+      });
+      const result = await res.json();
+      setMood({
+        emoji: moodEmojis[result.mood] || '🤔',
+        label: result.mood.charAt(0).toUpperCase() + result.mood.slice(1),
+        confidence: result.confidence,
+      });
+    } catch (err) {
+      console.error('Mood analysis failed', err);
+    }
+  };
+
   return (
     <main className="relative w-full h-dvh overflow-hidden select-none touch-none">
-      <CameraFeed />
-      <DetectionOverlay />
-      <ScanButton />
-      <MoodCard />
+      <CameraFeed videoRef={videoRef} />
+      <DetectionOverlay videoRef={videoRef} onDetection={setDetection} />
+      <ScanButton onClick={handleScan} />
+      <MoodCard mood={mood} />
     </main>
   );
 };
 
-export default App; 
+export default App;

--- a/frontend/src/components/CameraFeed.tsx
+++ b/frontend/src/components/CameraFeed.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import LensFX from './LensFX';
 
-const CameraFeed: React.FC = () => {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
+interface Props {
+  videoRef: React.RefObject<HTMLVideoElement>;
+}
+
+const CameraFeed: React.FC<Props> = ({ videoRef }) => {
 
   useEffect(() => {
     let stream: MediaStream;
@@ -47,4 +50,4 @@ const CameraFeed: React.FC = () => {
   );
 };
 
-export default CameraFeed; 
+export default CameraFeed;

--- a/frontend/src/components/DetectionOverlay.tsx
+++ b/frontend/src/components/DetectionOverlay.tsx
@@ -1,11 +1,77 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import * as cocoSsd from '@tensorflow-models/coco-ssd';
+import '@tensorflow/tfjs';
 
-const DetectionOverlay: React.FC = () => {
-  return (
-    <div className="absolute inset-0 pointer-events-none">
-      {/* Detection graphics will be drawn here */}
-    </div>
-  );
+export interface Detection {
+  bbox: [number, number, number, number];
+  class: string;
+  score: number;
+}
+
+interface Props {
+  videoRef: React.RefObject<HTMLVideoElement>;
+  onDetection?: (det: Detection | null) => void;
+}
+
+const DetectionOverlay: React.FC<Props> = ({ videoRef, onDetection }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    let model: cocoSsd.ObjectDetection | null = null;
+
+    async function loadModel() {
+      try {
+        model = await cocoSsd.load();
+        detectFrame();
+      } catch (err) {
+        console.error('Failed to load detection model', err);
+      }
+    }
+
+    async function detectFrame() {
+      if (!mounted || !model || !videoRef.current || !canvasRef.current) return;
+      const video = videoRef.current;
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+
+      try {
+        const predictions = await model.detect(video);
+        const faces = predictions.filter(p =>
+          ['person', 'dog', 'cat'].includes(p.class) && p.score > 0.25
+        );
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        let best: Detection | null = null;
+        if (faces.length > 0) {
+          faces.sort((a, b) => b.score - a.score);
+          const det = faces[0];
+          const [x, y, w, h] = det.bbox;
+          ctx.strokeStyle = '#10b981';
+          ctx.lineWidth = 4;
+          ctx.strokeRect(x, y, w, h);
+          best = { bbox: [x, y, w, h], class: det.class, score: det.score };
+        }
+        onDetection && onDetection(best);
+      } catch (err) {
+        console.error('Detection error', err);
+      }
+
+      requestAnimationFrame(detectFrame);
+    }
+
+    loadModel();
+    return () => {
+      mounted = false;
+    };
+  }, [videoRef, onDetection]);
+
+  return <canvas ref={canvasRef} className="absolute inset-0 pointer-events-none" />;
 };
 
-export default DetectionOverlay; 
+export default DetectionOverlay;

--- a/frontend/src/components/MoodCard.tsx
+++ b/frontend/src/components/MoodCard.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import LiquidGlass from './LiquidGlass';
 
-const MoodCard: React.FC = () => {
-  // Placeholder mood data; will be replaced by detection.
-  const mood = { emoji: '😌', label: 'Relaxed', confidence: 88 };
+interface Mood {
+  emoji: string;
+  label: string;
+  confidence: number;
+}
+
+interface Props {
+  mood: Mood | null;
+}
+
+const MoodCard: React.FC<Props> = ({ mood }) => {
+  if (!mood) return null;
 
   return (
     <div className="absolute inset-x-4 bottom-36 flex justify-center pointer-events-auto">
@@ -18,4 +27,4 @@ const MoodCard: React.FC = () => {
   );
 };
 
-export default MoodCard; 
+export default MoodCard;


### PR DESCRIPTION
## Summary
- detect dog, cat, or human faces via TensorFlow and draw green bounding boxes
- capture detected face for mood prediction and show emoji feedback
- expose video element ref for detection and update mood card rendering

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tensorflow-models%2fcoco-ssd)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "@tensorflow-models/coco-ssd")*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0ff865d608325b7127afe1f2b2d60